### PR TITLE
Parse the standard timezone

### DIFF
--- a/CalendarKit-Swift/SwiftCal/SwiftCal.swift
+++ b/CalendarKit-Swift/SwiftCal/SwiftCal.swift
@@ -66,6 +66,7 @@ public class Read {
             let headerScanner = Scanner(string: calendarEvents.first!)
             headerScanner.scanUpTo("TZID:", into: nil)
             headerScanner.scanUpTo("\n", into: &timezoneId)
+            headerScanner.scanUpTo("BEGIN:STANDARD", into: nil)
             headerScanner.scanUpTo("TZOFFSETTO:", into: nil)
             headerScanner.scanUpTo("\n", into: &timezoneOffset)
 


### PR DESCRIPTION
We need to parse `STANDARD` timezone since we are adjusting for daylight savings independently anyways. We were relying on `STANDARD` being the first in the list of timezones but now we are explicitly scanning for it, since there is no guarantee that it is always first.

Related issue https://github.com/superhuman/superhuman-ios/issues/2813