### PR TITLE
Default endDate to startDate when DTEND is missing in ics

### DIFF
--- a/CalendarKit-Swift/SwiftCal/ICSEventParser.swift
+++ b/CalendarKit-Swift/SwiftCal/ICSEventParser.swift
@@ -45,9 +45,12 @@ class ICSEventParser: NSObject {
         let startDateInfo = startDate(from: icsString, calendarTimezone: calendarTimezone)
         let endDateInfo = endDate(from: icsString, calendarTimezone: calendarTimezone)
 
-        guard let startDate = startDateInfo.date, let endDate = endDateInfo.date else {
+        guard let startDate = startDateInfo.date else {
             return nil
         }
+        
+        // https://tools.ietf.org/html/rfc5545 specifies that for VEVENTs missing a DTEND, the event ends at the same date and time as the start.
+        let endDate = endDateInfo.date ?? startDate
 
         guard let uniqueId = uniqueIdentifier(from: icsString) else {
             return nil

--- a/SwiftCalTests/ICSEventParserTests.swift
+++ b/SwiftCalTests/ICSEventParserTests.swift
@@ -33,5 +33,18 @@ class SwiftCalTests: XCTestCase {
         let icsLocationWithParametersEvent = ICSEventParser.event(from: icsLocationWithParameters)
         XCTAssertEqual(icsLocationWithParametersEvent?.location, location)
     }
-
+    
+    func testNoEndDate() {
+        let icsEventWithoutEnd = """
+        UID:E87642FC-0526-4FF2-88B2-4DDAE14C6A76\r
+        DTSTART;TZID=Pacific Standard Time:20201008T110000\r
+        END:VEVENT\r
+        END:VCALENDAR\r
+        """
+        
+        let parsedEvent = ICSEventParser.event(from: icsEventWithoutEnd)
+        
+        XCTAssertNotNil(parsedEvent?.endDate)
+        XCTAssertEqual(parsedEvent?.startDate, parsedEvent?.endDate)
+    }
 }


### PR DESCRIPTION
According to this RFC https://tools.ietf.org/html/rfc5545, we should default an event's end date to the start date when DTEND is missing.

>  For cases where a "VEVENT" calendar component specifies a "DTSTART" property with a DATE-TIME value type but no "DTEND" property, the event ends on the same calendar date and time of day specified by the "DTSTART" property.

https://github.com/superhuman/ios/issues/8441 contains an example of a user reported calendar event that is missing a DTEND component. Our parsing currently bails when DTEND end is missing. This PR fixes the issue by default endDate to startDate when DTEND is missing.